### PR TITLE
Remove the use of syscall within client fixes #13

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -137,8 +136,6 @@ func httpRequest(req *Request) (*http.Request, error) {
 
 func logError(err error) {
 	switch t := err.(type) {
-	case syscall.Errno:
-		fmt.Fprintf(os.Stderr, "syscall.Errno %d: %s\n", t, err.Error())
 	case net.Error:
 		fmt.Fprintf(os.Stderr, "net.Error timeout=%t, temp=%t: %s\n", t.Timeout(), t.Temporary(), err.Error())
 	default:


### PR DESCRIPTION
The syscall package is not available on all platforms, and banned on App Engine. The use of syscall was just to print out a syscall.Errno more clearly. However, syscall.Errno's own Error() method prints out details about the syscall. So other than a minor change to the logging output, this changes no functionality.