### PR TITLE
fixes .name with more whois information

### DIFF
--- a/adapter_name.go
+++ b/adapter_name.go
@@ -1,0 +1,22 @@
+package whois
+
+import (
+	"fmt"
+)
+
+type nameAdapter struct {
+	defaultAdapter
+}
+
+func (a *nameAdapter) Prepare(req *Request) error {
+	a.defaultAdapter.Prepare(req)
+	req.Body = []byte(fmt.Sprintf("=%s\r\n", req.Query))
+	return nil
+}
+
+func init() {
+	BindAdapter(
+		&nameAdapter{},
+		"whois.nic.name",
+	)
+}


### PR DESCRIPTION
### Basic information

```
# whois google.name

Disclaimer: VeriSign, Inc. makes every effort to maintain the
completeness and accuracy of the Whois data, but cannot guarantee
that the results are error-free. Therefore, any data provided
through the Whois service are on an as is basis without any
warranties.
BY USING THE WHOIS SERVICE AND THE DATA CONTAINED
HEREIN OR IN ANY REPORT GENERATED WITH RESPECT THERETO, IT IS
ACCEPTED THAT VERISIGN, INC. IS NOT LIABLE FOR
ANY DAMAGES OF ANY KIND ARISING OUT OF, OR IN CONNECTION WITH, THE
REPORT OR THE INFORMATION PROVIDED BY THE WHOIS SERVICE, NOR
OMISSIONS OR MISSING INFORMATION. THE RESULTS OF ANY WHOIS REPORT OR
INFORMATION PROVIDED BY THE WHOIS SERVICE CANNOT BE RELIED UPON IN
CONTEMPLATION OF LEGAL PROCEEDINGS WITHOUT FURTHER VERIFICATION, NOR
DO SUCH RESULTS CONSTITUTE A LEGAL OPINION. Acceptance of the
results of the Whois constitutes acceptance of these terms,
conditions and limitations. Whois data may be requested only for
lawful purposes, in particular, to protect legal rights and
obligations. Illegitimate uses of Whois data include, but are not
limited to, unsolicited email, data mining, direct marketing or any
other improper purpose. Any request made for Whois data will be
documented by VeriSign, Inc. but will not be used for any commercial purpose whatsoever.

 ****

 Registry Domain ID: 134538139_DOMAIN_NAME-VRSN
 Domain Name: GOOGLE.NAME
 Registrar: MarkMonitor Inc.
 Registrar IANA ID: 292
 Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
 Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
 Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
  
>>> Last update of whois database: 2018-07-14T05:22:52Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

To request access to data listed as “Redacted” or “Redacted for Privacy” in the
above WHOIS result, please contact Customer Service at info@verisign-grs.com
```
### More information

```
# whois =google.name

Disclaimer: VeriSign, Inc. makes every effort to maintain the
completeness and accuracy of the Whois data, but cannot guarantee
that the results are error-free. Therefore, any data provided
through the Whois service are on an as is basis without any
warranties.
BY USING THE WHOIS SERVICE AND THE DATA CONTAINED
HEREIN OR IN ANY REPORT GENERATED WITH RESPECT THERETO, IT IS
ACCEPTED THAT VERISIGN, INC. IS NOT LIABLE FOR
ANY DAMAGES OF ANY KIND ARISING OUT OF, OR IN CONNECTION WITH, THE
REPORT OR THE INFORMATION PROVIDED BY THE WHOIS SERVICE, NOR
OMISSIONS OR MISSING INFORMATION. THE RESULTS OF ANY WHOIS REPORT OR
INFORMATION PROVIDED BY THE WHOIS SERVICE CANNOT BE RELIED UPON IN
CONTEMPLATION OF LEGAL PROCEEDINGS WITHOUT FURTHER VERIFICATION, NOR
DO SUCH RESULTS CONSTITUTE A LEGAL OPINION. Acceptance of the
results of the Whois constitutes acceptance of these terms,
conditions and limitations. Whois data may be requested only for
lawful purposes, in particular, to protect legal rights and
obligations. Illegitimate uses of Whois data include, but are not
limited to, unsolicited email, data mining, direct marketing or any
other improper purpose. Any request made for Whois data will be
documented by VeriSign, Inc. but will not be used for any commercial purpose whatsoever.

 ****

   Registry Domain ID: 134538139_DOMAIN_NAME-VRSN
   Domain Name: GOOGLE.NAME
   Registrar: MarkMonitor Inc.
   Registrar IANA ID: 292
   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
   Registrar Abuse Contact Phone: +1.2083895740
   Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
   Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
   Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
   Registry Registrant ID: 14447011_CONTACT_NAME-VRSN
   Registry Admin ID: 14447011_CONTACT_NAME-VRSN
   Registry Tech ID: 14447011_CONTACT_NAME-VRSN
   Registry Billing ID: 14447011_CONTACT_NAME-VRSN
   Name Server: NS1.GOOGLE.COM
   Name Server ID: 69815439_HOST_NAME-VRSN
   Name Server: NS2.GOOGLE.COM
   Name Server ID: 69815440_HOST_NAME-VRSN
   Name Server: NS3.GOOGLE.COM
   Name Server ID: 69815441_HOST_NAME-VRSN
   Name Server: NS4.GOOGLE.COM
   Name Server ID: 69815442_HOST_NAME-VRSN
   Created On: 2010-06-17T00:46:09Z
   Expires On: 2019-06-17T00:46:12Z
   Updated On: 2018-05-16T09:33:11Z
   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/

>>> Last update of whois database: 2018-07-14T05:24:22Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

To request access to data listed as “Redacted” or “Redacted for Privacy” in the
above WHOIS result, please contact Customer Service at info@verisign-grs.com
```