### PR TITLE
Fix HTTP whois for .nr domains

### DIFF
--- a/adapter_nr.go
+++ b/adapter_nr.go
@@ -19,6 +19,7 @@ func (a *nrAdapter) Prepare(req *Request) error {
 	values := url.Values{}
 	values.Set("subdomain", labels[0])
 	values.Set("tld", labels[1])
+	values.Set("whois", "Submit")
 	req.URL = "http://www.cenpac.net.nr/dns/whois.html?" + values.Encode()
 	req.Body = nil // Always override existing request body
 	return nil


### PR DESCRIPTION
The HTTP whois for .nr domains seems to require an additional url parameter to return correct results **for not-registered domains**. So I added the url parameter to the .nr domain adapter.

Example:
- https://www.cenpac.net.nr/dns/whois.html?subdomain=3qceea2e2ac&tld=nr&whois=Submit returns an html page containing "This domain is not registered"
- https://www.cenpac.net.nr/dns/whois.html?subdomain=3qceea2e2ac&tld=nr does not return the correct result

In contrast, WHOIS records for existing domains are returned correctly with or without the "whois=Submit" param (see https://www.cenpac.net.nr/dns/whois.html?subdomain=google&tld=nr&whois=Submit).

PS: Thanks for the great project!