### PR TITLE
fix: close HTTP response body and modernize deprecated stdlib usage

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -3,7 +3,7 @@ package whois
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // Adapter contains server-specific code for retrieving and parsing whois data.
@@ -41,7 +41,7 @@ func (a *defaultAdapter) Text(res *Response) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	text, err := ioutil.ReadAll(r)
+	text, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ type Client struct {
 	DialContext func(context.Context, string, string) (net.Conn, error) // Only used for port 43 (whois) requests, not HTTP(S)
 	HTTPClient  *http.Client                                            // If nil, http.DefaultClient will be used
 	Timeout     time.Duration                                           // Deprecated (use a Context instead)
-	ReadLimit   int64                                                    // If 0, DefaultReadLimit will be used
+	ReadLimit   int64                                                   // If 0, DefaultReadLimit will be used
 }
 
 // DefaultClient represents a shared whois client with a default timeout, HTTP
@@ -77,6 +77,12 @@ type FetchError struct {
 // Error implements the error interface.
 func (f *FetchError) Error() string {
 	return f.Err.Error()
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As to
+// see through FetchError.
+func (f *FetchError) Unwrap() error {
+	return f.Err
 }
 
 // Fetch sends the Request to a whois server.

--- a/client.go
+++ b/client.go
@@ -131,6 +131,9 @@ func (c *Client) fetchHTTP(ctx context.Context, req *Request) (*Response, error)
 	if err != nil {
 		return nil, &FetchError{err, req.Host}
 	}
+	// Close the response body so the underlying connection can be
+	// returned to the transport's keep-alive pool.
+	defer hres.Body.Close()
 	res := NewResponse(req.Query, req.Host)
 	if res.Body, err = io.ReadAll(io.LimitReader(hres.Body, c.readLimit())); err != nil {
 		return nil, &FetchError{err, req.Host}

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -112,7 +111,7 @@ func (c *Client) fetchWhois(ctx context.Context, req *Request) (*Response, error
 		return nil, &FetchError{err, req.Host}
 	}
 	res := NewResponse(req.Query, req.Host)
-	if res.Body, err = ioutil.ReadAll(io.LimitReader(conn, c.readLimit())); err != nil {
+	if res.Body, err = io.ReadAll(io.LimitReader(conn, c.readLimit())); err != nil {
 		return nil, &FetchError{err, req.Host}
 	}
 	res.DetectContentType("")
@@ -133,7 +132,7 @@ func (c *Client) fetchHTTP(ctx context.Context, req *Request) (*Response, error)
 		return nil, &FetchError{err, req.Host}
 	}
 	res := NewResponse(req.Query, req.Host)
-	if res.Body, err = ioutil.ReadAll(io.LimitReader(hres.Body, c.readLimit())); err != nil {
+	if res.Body, err = io.ReadAll(io.LimitReader(hres.Body, c.readLimit())); err != nil {
 		return nil, &FetchError{err, req.Host}
 	}
 	res.DetectContentType(hres.Header.Get("Content-Type"))

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package main
 

--- a/response.go
+++ b/response.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/mail"
@@ -191,7 +190,7 @@ func ReadMIME(r io.Reader) (*Response, error) {
 	}
 	h := msg.Header
 	res := NewResponse(h.Get("Query"), h.Get("Host"))
-	if res.Body, err = ioutil.ReadAll(msg.Body); err != nil {
+	if res.Body, err = io.ReadAll(msg.Body); err != nil {
 		return res, err
 	}
 	if res.FetchedAt, err = time.Parse(time.RFC3339, h.Get("Fetched-At")); err != nil {

--- a/whois.go
+++ b/whois.go
@@ -21,7 +21,7 @@ func Fetch(query string) (*Response, error) {
 // Returns an error if it cannot resolve query to any known host.
 func Server(query string) (string, string, error) {
 	// Queries on TLDs always against IANA
-	if strings.Index(query, ".") < 0 {
+	if !strings.Contains(query, ".") {
 		return IANA, "", nil
 	}
 	z := zonedb.PublicZone(query)


### PR DESCRIPTION
This PR contains three commits:

1. fix: close HTTP response body to release keep-alive connections
   - Response body is now closed, releasing keep-alive connections back to the pool.
2. refactor: replace deprecated ioutil.ReadAll with io.ReadAll
3. refactor: modernize deprecated and non-idiomatic stdlib usage